### PR TITLE
add "ENCLOSED BY '"' " to the COPY inserter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RVertica
 Type: Package
 Title: Lightweight Connections to Vertica
-Version: 0.0.3
-Date: 2016-08-05
+Version: 0.0.4
+Date: 2016-08-25
 Author: Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'Vertica' provides ODBC and JDBC connectivity. This package

--- a/R/tables.R
+++ b/R/tables.R
@@ -28,7 +28,7 @@ psqlCommand <- function(sqlcmd) {
 ##' @return Nothing
 ##' @author Dirk Eddelbuettel
 psqlCopy <- function(data, table) {
-    cmd <- sprintf("%s -c \"COPY %s FROM STDIN USING DELIMITERS ',';\"", .pkgenv$psqlpath, table)
+    cmd <- sprintf("%s -c \"COPY %s FROM STDIN USING DELIMITERS ',' ENCLOSED BY '\\\"';\"", .pkgenv$psqlpath, table)
     write.table(data, file=pipe(cmd), row.names = FALSE, col.names = FALSE, sep=",")
     invisible(NULL)
 }


### PR DESCRIPTION
Now doing

``` r
library(RVertica)
dat <- data.frame(testvarchar=c("AK", "AL"), testint=c(3,4))
psqlCopy(dat, "test_rvertica_copy")
```

results in the desired 'no quotes' table:

``` bash
~/vertica/shell$ psql -c 'select * from test_rvertica_copy;'
 testvarchar | testint 
-------------+---------
 AK          | 3
 AL          | 4
(2 rows)

~/vertica/shell$ 
```
